### PR TITLE
Animate node movement

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -106,7 +106,7 @@ export default function initHtml(visualizer) {
         if (!value.length || Number.isNaN(+value)) return;
 
         visualizer.inserting = true;
-        insertNode(visualizer, value)
+        insertNode(visualizer, +value)
             .then((tree) => {
                 visualizer.tree      = tree
                 visualizer.inserting = false;


### PR DESCRIPTION
Animate node movement when fixing collisions.
In the past, nodes used to teleport to the correct location instantly, but now they will be animated smoothly.